### PR TITLE
Pointer arithmetic on void pointer is undefined behavior

### DIFF
--- a/_parts/part8.md
+++ b/_parts/part8.md
@@ -93,11 +93,11 @@ The code to access keys, values and metadata all involve pointer arithmetic usin
 
 ```diff
 +uint32_t* leaf_node_num_cells(void* node) {
-+  return node + LEAF_NODE_NUM_CELLS_OFFSET;
++  return (char *)node + LEAF_NODE_NUM_CELLS_OFFSET;
 +}
 +
 +void* leaf_node_cell(void* node, uint32_t cell_num) {
-+  return node + LEAF_NODE_HEADER_SIZE + cell_num * LEAF_NODE_CELL_SIZE;
++  return (char *)node + LEAF_NODE_HEADER_SIZE + cell_num * LEAF_NODE_CELL_SIZE;
 +}
 +
 +uint32_t* leaf_node_key(void* node, uint32_t cell_num) {


### PR DESCRIPTION
It's undefined behavior since pointer arithmetic needs to know the sizeof the pointed type, and there's no `void` type that sizeof() will work on.  By casting the pointer to a char*, the compiler can safely use sizeof(char) in order to perform the calculation.