### PR TITLE
repace `eq` with `match_array` in spec

### DIFF
--- a/_parts/part10.md
+++ b/_parts/part10.md
@@ -409,7 +409,7 @@ Here's a test case for the new printing functionality!
 +    script << ".exit"
 +    result = run_script(script)
 +
-+    expect(result[14...(result.length)]).to eq([
++    expect(result[14...(result.length)]).to match_array([
 +      "db > Tree:",
 +      "- internal (size 1)",
 +      "  - leaf (size 7)",

--- a/_parts/part11.md
+++ b/_parts/part11.md
@@ -102,7 +102,7 @@ And that reveals that our 1400-row test outputs this error:
      script << ".exit"
      result = run_script(script)
 -    expect(result[-2]).to eq('db > Error: Table full.')
-+    expect(result.last(2)).to eq([
++    expect(result.last(2)).to match_array([
 +      "db > Executed.",
 +      "db > Need to implement updating parent after split",
 +    ])

--- a/_parts/part12.md
+++ b/_parts/part12.md
@@ -15,7 +15,7 @@ We now support constructing a multi-level btree, but we've broken `select` state
 +    script << ".exit"
 +    result = run_script(script)
 +
-+    expect(result[15...result.length]).to eq([
++    expect(result[15...result.length]).to match_array([
 +      "db > (1, user1, person1@example.com)",
 +      "(2, user2, person2@example.com)",
 +      "(3, user3, person3@example.com)",

--- a/_parts/part13.md
+++ b/_parts/part13.md
@@ -182,7 +182,7 @@ Speaking of tests, our large-dataset test gets past our old stub and gets to our
 ```diff
 @@ -65,7 +65,7 @@ describe 'database' do
      result = run_script(script)
-     expect(result.last(2)).to eq([
+     expect(result.last(2)).to match_array([
        "db > Executed.",
 -      "db > Need to implement updating parent after split",
 +      "db > Need to implement splitting internal node",

--- a/_parts/part4.md
+++ b/_parts/part4.md
@@ -32,7 +32,7 @@ describe 'database' do
       "select",
       ".exit",
     ])
-    expect(result).to eq([
+    expect(result).to match_array([
       "db > Executed.",
       "db > (1, user1, person1@example.com)",
       "Executed.",
@@ -85,7 +85,7 @@ it 'allows inserting strings that are the maximum length' do
     ".exit",
   ]
   result = run_script(script)
-  expect(result).to eq([
+  expect(result).to match_array([
     "db > Executed.",
     "db > (1, #{long_username}, #{long_email})",
     "Executed.",
@@ -151,7 +151,7 @@ it 'prints error message if strings are too long' do
     ".exit",
   ]
   result = run_script(script)
-  expect(result).to eq([
+  expect(result).to match_array([
     "db > String is too long.",
     "db > Executed.",
     "db > ",
@@ -263,7 +263,7 @@ it 'prints an error message if id is negative' do
     ".exit",
   ]
   result = run_script(script)
-  expect(result).to eq([
+  expect(result).to match_array([
     "db > ID must be positive.",
     "db > Executed.",
     "db > ",
@@ -410,7 +410,7 @@ And we added tests:
 +      "select",
 +      ".exit",
 +    ])
-+    expect(result).to eq([
++    expect(result).to match_array([
 +      "db > Executed.",
 +      "db > (1, user1, person1@example.com)",
 +      "Executed.",
@@ -436,7 +436,7 @@ And we added tests:
 +      ".exit",
 +    ]
 +    result = run_script(script)
-+    expect(result).to eq([
++    expect(result).to match_array([
 +      "db > Executed.",
 +      "db > (1, #{long_username}, #{long_email})",
 +      "Executed.",
@@ -453,7 +453,7 @@ And we added tests:
 +      ".exit",
 +    ]
 +    result = run_script(script)
-+    expect(result).to eq([
++    expect(result).to match_array([
 +      "db > String is too long.",
 +      "db > Executed.",
 +      "db > ",
@@ -467,7 +467,7 @@ And we added tests:
 +      ".exit",
 +    ]
 +    result = run_script(script)
-+    expect(result).to eq([
++    expect(result).to match_array([
 +      "db > ID must be positive.",
 +      "db > Executed.",
 +      "db > ",

--- a/_parts/part5.md
+++ b/_parts/part5.md
@@ -13,7 +13,7 @@ it 'keeps data after closing connection' do
     "insert 1 user1 person1@example.com",
     ".exit",
   ])
-  expect(result1).to eq([
+  expect(result1).to match_array([
     "db > Executed.",
     "db > ",
   ])
@@ -21,7 +21,7 @@ it 'keeps data after closing connection' do
     "select",
     ".exit",
   ])
-  expect(result2).to eq([
+  expect(result2).to match_array([
     "db > (1, user1, person1@example.com)",
     "Executed.",
     "db > ",
@@ -533,7 +533,7 @@ index 21561ce..bc0180a 100644
 +      "insert 1 user1 person1@example.com",
 +      ".exit",
 +    ])
-+    expect(result1).to eq([
++    expect(result1).to match_array([
 +      "db > Executed.",
 +      "db > ",
 +    ])
@@ -542,7 +542,7 @@ index 21561ce..bc0180a 100644
 +      "select",
 +      ".exit",
 +    ])
-+    expect(result2).to eq([
++    expect(result2).to match_array([
 +      "db > (1, user1, person1@example.com)",
 +      "Executed.",
 +      "db > ",
@@ -577,7 +577,7 @@ And the diff to our tests:
 +      "insert 1 user1 person1@example.com",
 +      ".exit",
 +    ])
-+    expect(result1).to eq([
++    expect(result1).to match_array([
 +      "db > Executed.",
 +      "db > ",
 +    ])
@@ -586,7 +586,7 @@ And the diff to our tests:
 +      "select",
 +      ".exit",
 +    ])
-+    expect(result2).to eq([
++    expect(result2).to match_array([
 +      "db > (1, user1, person1@example.com)",
 +      "Executed.",
 +      "db > ",

--- a/_parts/part8.md
+++ b/_parts/part8.md
@@ -417,7 +417,7 @@ I'm also adding a test so we get alerted when those constants change:
 +    ]
 +    result = run_script(script)
 +
-+    expect(result).to eq([
++    expect(result).to match_array([
 +      "db > Constants:",
 +      "ROW_SIZE: 293",
 +      "COMMON_NODE_HEADER_SIZE: 6",
@@ -477,7 +477,7 @@ And a test
 +    script << ".exit"
 +    result = run_script(script)
 +
-+    expect(result).to eq([
++    expect(result).to match_array([
 +      "db > Executed.",
 +      "db > Executed.",
 +      "db > Executed.",
@@ -829,7 +829,7 @@ And the specs:
 +    script << ".exit"
 +    result = run_script(script)
 +
-+    expect(result).to eq([
++    expect(result).to match_array([
 +      "db > Executed.",
 +      "db > Executed.",
 +      "db > Executed.",
@@ -849,7 +849,7 @@ And the specs:
 +    ]
 +    result = run_script(script)
 +
-+    expect(result).to eq([
++    expect(result).to match_array([
 +      "db > Constants:",
 +      "ROW_SIZE: 293",
 +      "COMMON_NODE_HEADER_SIZE: 6",

--- a/_parts/part9.md
+++ b/_parts/part9.md
@@ -184,7 +184,7 @@ And we can add a new test for duplicate keys:
 +      ".exit",
 +    ]
 +    result = run_script(script)
-+    expect(result).to eq([
++    expect(result).to match_array([
 +      "db > Executed.",
 +      "db > Error: Duplicate key.",
 +      "db > (1, user1, person1@example.com)",

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -28,7 +28,7 @@ describe 'database' do
       "select",
       ".exit",
     ])
-    expect(result).to eq([
+    expect(result).to match_array([
       "db > Executed.",
       "db > (1, user1, person1@example.com)",
       "Executed.",
@@ -41,7 +41,7 @@ describe 'database' do
       "insert 1 user1 person1@example.com",
       ".exit",
     ])
-    expect(result1).to eq([
+    expect(result1).to match_array([
       "db > Executed.",
       "db > ",
     ])
@@ -50,7 +50,7 @@ describe 'database' do
       "select",
       ".exit",
     ])
-    expect(result2).to eq([
+    expect(result2).to match_array([
       "db > (1, user1, person1@example.com)",
       "Executed.",
       "db > ",
@@ -63,7 +63,7 @@ describe 'database' do
     end
     script << ".exit"
     result = run_script(script)
-    expect(result.last(2)).to eq([
+    expect(result.last(2)).to match_array([
       "db > Executed.",
       "db > Need to implement splitting internal node",
     ])
@@ -78,7 +78,7 @@ describe 'database' do
       ".exit",
     ]
     result = run_script(script)
-    expect(result).to eq([
+    expect(result).to match_array([
       "db > Executed.",
       "db > (1, #{long_username}, #{long_email})",
       "Executed.",
@@ -95,7 +95,7 @@ describe 'database' do
       ".exit",
     ]
     result = run_script(script)
-    expect(result).to eq([
+    expect(result).to match_array([
       "db > String is too long.",
       "db > Executed.",
       "db > ",
@@ -109,7 +109,7 @@ describe 'database' do
       ".exit",
     ]
     result = run_script(script)
-    expect(result).to eq([
+    expect(result).to match_array([
       "db > ID must be positive.",
       "db > Executed.",
       "db > ",
@@ -124,7 +124,7 @@ describe 'database' do
       ".exit",
     ]
     result = run_script(script)
-    expect(result).to eq([
+    expect(result).to match_array([
       "db > Executed.",
       "db > Error: Duplicate key.",
       "db > (1, user1, person1@example.com)",
@@ -141,7 +141,7 @@ describe 'database' do
     script << ".exit"
     result = run_script(script)
 
-    expect(result).to eq([
+    expect(result).to match_array([
       "db > Executed.",
       "db > Executed.",
       "db > Executed.",
@@ -163,7 +163,7 @@ describe 'database' do
     script << ".exit"
     result = run_script(script)
 
-    expect(result[14...(result.length)]).to eq([
+    expect(result[14...(result.length)]).to match_array([
       "db > Tree:",
       "- internal (size 1)",
       "  - leaf (size 7)",
@@ -225,7 +225,7 @@ describe 'database' do
     ]
     result = run_script(script)
 
-    expect(result[30...(result.length)]).to eq([
+    expect(result[30...(result.length)]).to match_array([
       "db > Tree:",
       "- internal (size 3)",
       "  - leaf (size 7)",
@@ -276,7 +276,7 @@ describe 'database' do
     ]
     result = run_script(script)
 
-    expect(result).to eq([
+    expect(result).to match_array([
       "db > Constants:",
       "ROW_SIZE: 293",
       "COMMON_NODE_HEADER_SIZE: 6",
@@ -296,7 +296,7 @@ describe 'database' do
     script << "select"
     script << ".exit"
     result = run_script(script)
-    expect(result[15...result.length]).to eq([
+    expect(result[15...result.length]).to match_array([
       "db > (1, user1, person1@example.com)",
       "(2, user2, person2@example.com)",
       "(3, user3, person3@example.com)",


### PR DESCRIPTION
this will generate more readable error message, like
![image](https://user-images.githubusercontent.com/876694/34048949-8e3955c2-e1f0-11e7-8a0b-3c3348318a49.png)
