### PR TITLE
fix uninitialized root_page_num

### DIFF
--- a/db.c
+++ b/db.c
@@ -498,6 +498,7 @@ Table* db_open(const char* filename) {
 
   Table* table = malloc(sizeof(Table));
   table->pager = pager;
+  table->root_page_num = 0;
 
   if (pager->num_pages == 0) {
     // New database file. Initialize page 0 as leaf node.


### PR DESCRIPTION
When running db.c, I got the following error.
```
$ make
gcc db.c -o db
$ make run
./db mydb.db
db > select
Tried to fetch page number out of bounds. -1491861502 > 100
make: *** [run] Error 1
```

I think uninitialized root_page_num variable causes this error.

**Environment**
OS: OSX 10.11.6
```
# gcc -v
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 8.0.0 (clang-800.0.38)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

Thanks.