### PR TITLE
Fix bug EXECUTE_DUPLICATE_KEY

### DIFF
--- a/db.c
+++ b/db.c
@@ -350,7 +350,7 @@ Cursor* leaf_node_find(Table* table, uint32_t page_num, uint32_t key) {
   Cursor* cursor = malloc(sizeof(Cursor));
   cursor->table = table;
   cursor->page_num = page_num;
-	cursor->end_of_table = false;
+  cursor->end_of_table = false;
 
   // Binary search
   uint32_t min_index = 0;

--- a/db.c
+++ b/db.c
@@ -808,12 +808,12 @@ void leaf_node_insert(Cursor* cursor, uint32_t key, Row* value) {
 }
 
 ExecuteResult execute_insert(Statement* statement, Table* table) {
-  void* node = get_page(table->pager, table->root_page_num);
-  uint32_t num_cells = (*leaf_node_num_cells(node));
-
   Row* row_to_insert = &(statement->row_to_insert);
   uint32_t key_to_insert = row_to_insert->id;
   Cursor* cursor = table_find(table, key_to_insert);
+
+  void *node = get_page(table->pager, cursor->page_num);
+  uint32_t num_cells = *leaf_node_num_cells(node);
 
   if (cursor->cell_num < num_cells) {
     uint32_t key_at_index = *leaf_node_key(node, cursor->cell_num);

--- a/db.c
+++ b/db.c
@@ -350,6 +350,7 @@ Cursor* leaf_node_find(Table* table, uint32_t page_num, uint32_t key) {
   Cursor* cursor = malloc(sizeof(Cursor));
   cursor->table = table;
   cursor->page_num = page_num;
+	cursor->end_of_table = false;
 
   // Binary search
   uint32_t min_index = 0;


### PR DESCRIPTION
- You should get page pointed to by the cursor, not the root page to check for EXECUTE_DUPLICATE_KEY.
- Sometimes cursor->end_of_table is set to true if you don't initialize it to false by hand.