### PR TITLE
Cosmetic changes

### DIFF
--- a/_parts/part5.md
+++ b/_parts/part5.md
@@ -241,7 +241,7 @@ In our current design, the length of the file encodes how many rows are in the d
 +}
 ```
 
-Lastly, we need to accept the filename as a command-line argument:
+Lastly, we need to accept the filename as a command-line argument. Don't forget to also add the extra argument to `do_meta_command`:
 
 ```diff
  int main(int argc, char* argv[]) {
@@ -254,6 +254,14 @@ Lastly, we need to accept the filename as a command-line argument:
 +  char* filename = argv[1];
 +  Table* table = db_open(filename);
 +
+   InputBuffer* input_buffer = new_input_buffer();
+   while (true) {
+     print_prompt();
+     read_input(input_buffer);
+ 
+     if (input_buffer->buffer[0] == '.') {
+-      switch (do_meta_command(input_buffer)) {
++      switch (do_meta_command(input_buffer, table)) {
 ```
 With these changes, we're able to close then reopen the database, and our records are still there!
 

--- a/_parts/part8.md
+++ b/_parts/part8.md
@@ -298,7 +298,7 @@ A cursor represents a position in the table. When our table was a simple array o
 
 ## Insertion Into a Leaf Node
 
-In this article we're only going to implement enough to get get a single-node tree. Recall from last article that a tree starts out as an empty leaf node:
+In this article we're only going to implement enough to get a single-node tree. Recall from last article that a tree starts out as an empty leaf node:
 
 {% include image.html url="assets/images/btree1.png" description="empty btree" %}
 


### PR DESCRIPTION
In part 5, altering the call of `do_meta_command()` in `main` is only shown in the compete diff at the end. This slightly threw me off, so I was thinking it might be nicer to include all diffs before the end, so that the reader can simply go through the post and have the code compile, without looking through the complete diff (or compiler errors). Just a thought, feel free veto it since it is pretty obvious.

The other change is deleting a duplicated word.

Thank you for creating this amazing tutorial, it's helped me a lot already.