### PR TITLE
Fix if statement based off of uninitialized value in part3

### DIFF
--- a/_parts/part3.md
+++ b/_parts/part3.md
@@ -185,7 +185,7 @@ Lastly, we need to initialize the table and handle a few more error cases:
 
 ```diff
 + Table* new_table() {
-+  Table* table = malloc(sizeof(Table));
++  Table* table = calloc(sizeof(Table));
 +  table->num_rows = 0;
 +
 +  return table;
@@ -334,7 +334,7 @@ We'll address those issues in the next part. For now, here's the complete diff f
 +}
 +
 +Table* new_table() {
-+  Table* table = malloc(sizeof(Table));
++  Table* table = calloc(sizeof(Table));
 +  table->num_rows = 0;
 +
 +  return table;

--- a/_parts/part5.md
+++ b/_parts/part5.md
@@ -66,7 +66,7 @@ I'm renaming `new_table()` to `db_open()` because it now has the effect of openi
 +  Pager* pager = pager_open(filename);
 +  uint32_t num_rows = pager->file_length / ROW_SIZE;
 +
-   Table* table = malloc(sizeof(Table));
+   Table* table = calloc(sizeof(Table));
 -  table->num_rows = 0;
 +  table->pager = pager;
 +  table->num_rows = num_rows;
@@ -413,7 +413,7 @@ Until then!
 +  Pager* pager = pager_open(filename);
 +  uint32_t num_rows = pager->file_length / ROW_SIZE;
 +
-   Table* table = malloc(sizeof(Table));
+   Table* table = calloc(sizeof(Table));
 -  table->num_rows = 0;
 +  table->pager = pager;
 +  table->num_rows = num_rows;


### PR DESCRIPTION
In part 3, the `new_table` function allocates a new `Table` value using `malloc`, then only initializes the `table->num_rows` variable. The actual table of page pointers is still uninitialized. The first time `row_slot` is called on that table, it checks `table->pages[0]` to see if it is NULL or not (minor ub problem there as well). However the page pointers were never initialized so it might be a non-null garbage pointer which we then dereference and write into.

This patch replaces the call to `malloc` in `new_table` with `calloc`, which initializes the pointers to zero.