### PR TITLE
Add missing ExecuteResult definition'

### DIFF
--- a/_parts/part3.md
+++ b/_parts/part3.md
@@ -178,6 +178,11 @@ Now we can make `execute_statement` read/write from our table structure:
  }
 ```
 
+Let's also define `ExecuteResult`:
+```diff
++typedef enum { EXECUTE_SUCCESS, EXECUTE_TABLE_FULL } ExecuteResult;
+```
+
 Lastly, we need to initialize the table, create the respective
 memory release function and handle a few more error cases:
 


### PR DESCRIPTION
Add the missing `ExecuteResult` definition in part3.