### PR TITLE
Unify the way enum is defined with simpler typedef

### DIFF
--- a/_parts/part9.md
+++ b/_parts/part9.md
@@ -136,12 +136,12 @@ We also need to initialize node type.
 Lastly, we need to make and handle a new error code.
 
 ```diff
--enum ExecuteResult_t { EXECUTE_SUCCESS, EXECUTE_TABLE_FULL };
-+enum ExecuteResult_t {
+-typedef enum { EXECUTE_SUCCESS, EXECUTE_TABLE_FULL } ExecuteResult;
++typedef enum {
 +  EXECUTE_SUCCESS,
 +  EXECUTE_DUPLICATE_KEY,
 +  EXECUTE_TABLE_FULL
-+};
++} ExecuteResult;
 ```
 
 ```diff


### PR DESCRIPTION
I found a code that appears to be an omission in the modification of #37.